### PR TITLE
Fixed the issue that given object may not has hasOwnProperty function

### DIFF
--- a/src/query-builder/transformer/PlainObjectToNewEntityTransformer.ts
+++ b/src/query-builder/transformer/PlainObjectToNewEntityTransformer.ts
@@ -28,12 +28,12 @@ export class PlainObjectToNewEntityTransformer {
 
         // copy regular column properties from the given object
         metadata.columns
-            .filter(column => object.hasOwnProperty(column.propertyName))
+            .filter(column => column.propertyName in object)
             .forEach(column => entity[column.propertyName] = object[column.propertyName]); // todo: also need to be sure that type is correct
 
         // if relation is loaded then go into it recursively and transform its values too
         metadata.relations
-            .filter(relation => object.hasOwnProperty(relation.propertyName))
+            .filter(relation => relation.propertyName in object)
             .forEach(relation => {
                 const relationMetadata = relation.inverseEntityMetadata;
                 if (!relationMetadata)


### PR DESCRIPTION
If the given object does not come from standard object, it will not have the "hasOwnProperty" function and raise error.

Lots of library in node (e.g. graphql) is creating object by Object.create(null) and does not "hasOwnProperty".

https://stackoverflow.com/questions/16585209/node-js-object-object-has-no-method-hasownproperty